### PR TITLE
Fixes #18: setup phase state

### DIFF
--- a/core/src/group16/project/game/controllers/InputHandler.kt
+++ b/core/src/group16/project/game/controllers/InputHandler.kt
@@ -1,9 +1,11 @@
 package group16.project.game.controllers
 
+import com.badlogic.gdx.math.MathUtils
+
 
 object InputHandler {
     var playerPosition = 0f
-    var enemyPosition = 0f
+    var enemyPosition = MathUtils.random(0f, 3f)
 
     var playerTrajectoryPosition = 0f
     var enemyTrajectoryPosition = 0f

--- a/core/src/group16/project/game/controllers/InputHandler.kt
+++ b/core/src/group16/project/game/controllers/InputHandler.kt
@@ -5,7 +5,7 @@ import com.badlogic.gdx.math.MathUtils
 
 object InputHandler {
     var playerPosition = 0f
-    var enemyPosition = MathUtils.random(0f, 3f)
+    var enemyPosition = MathUtils.random(0f, 3f).toInt()
 
     var playerTrajectoryPosition = 0f
     var enemyTrajectoryPosition = 0f

--- a/core/src/group16/project/game/ecs/component/HealthComponent.kt
+++ b/core/src/group16/project/game/ecs/component/HealthComponent.kt
@@ -7,16 +7,15 @@ class HealthComponent : Component {
 
     var hp = 2
 
-
-    public fun addListener(listener : HealthListener) {
+    fun addListener(listener : HealthListener) {
         listeners.add(listener);
     }
 
-    public fun increase() {
+    fun increase() {
         hp++;
         fireHealthChanged()
     }
-    public fun decrease() {
+    fun decrease() {
         hp--;
         fireHealthChanged()
     }
@@ -25,7 +24,7 @@ class HealthComponent : Component {
             listener.healthChanged()
         }
     }
-    public fun get(): Int {
+    fun get(): Int {
         return hp;
     }
 }

--- a/core/src/group16/project/game/ecs/component/HeartDisplayComponent.kt
+++ b/core/src/group16/project/game/ecs/component/HeartDisplayComponent.kt
@@ -1,24 +1,24 @@
 package group16.project.game.ecs.component
 
 import com.badlogic.ashley.core.Component
-import com.badlogic.ashley.core.ComponentMapper
 import com.badlogic.ashley.core.Entity
 import com.badlogic.gdx.graphics.Texture
+import group16.project.game.ecs.utils.ComponentMapper
 
 
 class HeartDisplayComponent : Component, HealthListener {
     private lateinit var health: HealthComponent
-    private val positionComponentMapper = ComponentMapper.getFor(PositionComponent::class.java)
+    private val positionComponentMapper = ComponentMapper.position
     private var displays: ArrayList<Entity> = ArrayList()
     val texture: Texture = Texture("heart_full.png")
     var hearts = -1
     val textureEmpty: Texture = Texture("heart.png")
 
-    public fun updateHearts(){
+    fun updateHearts(){
         hearts = health.get()
     }
 
-    public fun listenTo(health : HealthComponent) {
+    fun listenTo(health : HealthComponent) {
         health.addListener(this)
         this.health = health
         updateHearts()

--- a/core/src/group16/project/game/ecs/component/TransformComponent.kt
+++ b/core/src/group16/project/game/ecs/component/TransformComponent.kt
@@ -4,4 +4,6 @@ import com.badlogic.ashley.core.Component
 
 class TransformComponent : Component {
     var rotation = 0f
+    var flipped = false
+    var opacity = 0f
 }

--- a/core/src/group16/project/game/ecs/system/HeartSystem.kt
+++ b/core/src/group16/project/game/ecs/system/HeartSystem.kt
@@ -24,34 +24,29 @@ class HeartSystem (
     private val heartDisplayComponentMapper = ComponentMapper.getFor(HeartDisplayComponent::class.java)
 
     override fun update(deltaTime: Float) {
-        // Tell the camera to update its matrices
         batch.begin()
-
         super.update(deltaTime)
-
-
         batch.end()
     }
 
     override fun processEntity(entity: Entity?, deltaTime: Float) {
         notNull(
-                positionComponentMapper[entity],
-                bodyComponentMapper[entity],
-                heartDisplayComponentMapper[entity],
-                ::render
+            positionComponentMapper[entity],
+            bodyComponentMapper[entity],
+            heartDisplayComponentMapper[entity],
+            ::render
         )
     }
 
     private fun render(positionComponent: PositionComponent, bodyComponent: BodyComponent, heartDisplayComponent: HeartDisplayComponent) {
         val rectShape = bodyComponent.rectangle
-        println("Derp")
-        println(positionComponent.y)
-        println(Configuration.gameHeight-60f)
-        println("end derp")
-        heartDisplayComponent.hearts = 2
-        for (i in 1..3) {
-            if(heartDisplayComponent.hearts < i) batch.draw(heartDisplayComponent.textureEmpty, positionComponent.x + (i-1)*rectShape.width, positionComponent.y, rectShape.width, rectShape.height)
-            else batch.draw(heartDisplayComponent.texture, positionComponent.x + (i-1)*rectShape.width, positionComponent.y, rectShape.width, rectShape.height)
+        var isPlayer = false
+        if (positionComponent.x < 100)
+            isPlayer = true
+
+        for (i in 0..2) {
+            if(heartDisplayComponent.hearts < i+1 && isPlayer || heartDisplayComponent.hearts < 3-i && !isPlayer) batch.draw(heartDisplayComponent.textureEmpty, positionComponent.x + i*rectShape.width, positionComponent.y, rectShape.width, rectShape.height)
+            else batch.draw(heartDisplayComponent.texture, positionComponent.x + i*rectShape.width, positionComponent.y, rectShape.width, rectShape.height)
         }
     }
 }

--- a/core/src/group16/project/game/ecs/system/RenderingSystem.kt
+++ b/core/src/group16/project/game/ecs/system/RenderingSystem.kt
@@ -60,6 +60,8 @@ class RenderingSystem(
         sprite.setOrigin(rectShape.width/2, rectShape.height/2)
         sprite.setSize(rectShape.width, rectShape.height)
         sprite.rotation = transformComponent.rotation
+        sprite.setAlpha(transformComponent.opacity)
+        sprite.flip(transformComponent.flipped, false);
         sprite.draw(batch)
     }
 }

--- a/core/src/group16/project/game/ecs/system/ShieldSystem.kt
+++ b/core/src/group16/project/game/ecs/system/ShieldSystem.kt
@@ -2,14 +2,13 @@ package group16.project.game.ecs.system
 
 class ShieldSystem {
 
-
-    public fun increase() {
+    fun increase() {
         //if the ufo and shield are at the same spot, increase the shield strength
       //  if
         //    shield++;
     }
 
-    public fun decrease() {
+    fun decrease() {
         //if the ufo is hit by a bullet, decrease the shield strength
        // if..
          //   shield--;

--- a/core/src/group16/project/game/ecs/utils/EntityFactory.kt
+++ b/core/src/group16/project/game/ecs/utils/EntityFactory.kt
@@ -65,6 +65,11 @@ class EntityFactory {
                 entity.add(engine.createComponent(HealthComponent::class.java).apply {
                     hp = 3
                 })
+                entity.add(engine.createComponent(TransformComponent::class.java).apply {
+                    rotation = 0f
+                    flipped = !isPlayer
+                    opacity = 1f
+                })
             }
 
         fun createTarget(engine: Engine, posx: Float, posy: Float, isPlayer: Boolean) =
@@ -118,6 +123,8 @@ class EntityFactory {
             })
             entity.add(engine.createComponent(TransformComponent::class.java).apply {
                 rotation = 0f
+                flipped = false
+                opacity = 1f
             })
 
         }

--- a/core/src/group16/project/game/ecs/utils/EntityFactory.kt
+++ b/core/src/group16/project/game/ecs/utils/EntityFactory.kt
@@ -90,6 +90,11 @@ class EntityFactory {
                 entity.add(engine.createComponent(TargetComponent::class.java).apply {
                     player = isPlayer
                 })
+                entity.add(engine.createComponent(TransformComponent::class.java).apply {
+                    rotation = 0f
+                    flipped = false
+                    opacity = if (isPlayer) 1f else 0f
+                })
             }
 
         fun createTrajectory(

--- a/core/src/group16/project/game/models/Game.kt
+++ b/core/src/group16/project/game/models/Game.kt
@@ -38,6 +38,7 @@ class Game(private val screenRect: Rectangle, private val camera: OrthographicCa
         engine.addEntity(EntityFactory.createHearts(engine, 10f, Configuration.gameHeight - 60f, ship1.getComponent(HealthComponent::class.java)))
         engine.addEntity(EntityFactory.createHearts(engine, Configuration.gameWidth - 60f - 160f, Configuration.gameHeight - 60f, ship2.getComponent(HealthComponent::class.java)))
 
+        state = GameState.START
         Gdx.app.log("MODEL", "Engine loaded")
     }
 

--- a/core/src/group16/project/game/models/Game.kt
+++ b/core/src/group16/project/game/models/Game.kt
@@ -21,9 +21,10 @@ class Game(private val screenRect: Rectangle, private val camera: OrthographicCa
                 screenRect = screenRect
         )
     }
+    var state: GameState = GameState.START
 
     fun init() {
-        // Ship
+        // Ships
         val ship1: Entity = EntityFactory.createUfo(engine, -10f, 0f, true)
         val ship2: Entity = EntityFactory.createUfo(engine, Configuration.gameWidth - 170f, 0f, false)
         engine.addEntity(ship1)
@@ -33,35 +34,28 @@ class Game(private val screenRect: Rectangle, private val camera: OrthographicCa
         engine.addEntity(EntityFactory.createTarget(engine, 10f, 0f, false))
         // Background
         engine.addEntity(EntityFactory.createBG(engine, 0f, 0f))
-        // Hearts
-        /*
-        engine.addEntity(EntityFactory.createHearts(engine, 10f, Configuration.gameHeight - 70f))
-        engine.addEntity(EntityFactory.createHearts(engine, 70f, Configuration.gameHeight - 70f))
-        engine.addEntity(EntityFactory.createHearts(engine, 130f, Configuration.gameHeight - 70f))
-
-        engine.addEntity(EntityFactory.createHearts(engine, Configuration.gameWidth - 70f - 10f, Configuration.gameHeight - 70f))
-        engine.addEntity(EntityFactory.createHearts(engine, Configuration.gameWidth - 70f - 70f, Configuration.gameHeight - 70f))
-        engine.addEntity(EntityFactory.createHearts(engine, Configuration.gameWidth - 70f - 130f, Configuration.gameHeight - 70f))
-*/
-        // Trajectories
-        engine.addEntity(EntityFactory.createTrajectory(engine, Configuration.gameWidth - 160f, 0f, true, 10f, 0f))
-        engine.addEntity(EntityFactory.createTrajectory(engine, 10f, 0f, false, Configuration.gameWidth - 160f, 0f))
-
         //Hearts
         engine.addEntity(EntityFactory.createHearts(engine, 10f, Configuration.gameHeight - 60f, ship1.getComponent(HealthComponent::class.java)))
-        engine.addEntity(EntityFactory.createHearts(engine, Configuration.gameWidth - 50f - 130f, Configuration.gameHeight - 60f, ship1.getComponent(HealthComponent::class.java)))
+        engine.addEntity(EntityFactory.createHearts(engine, Configuration.gameWidth - 60f - 160f, Configuration.gameHeight - 60f, ship2.getComponent(HealthComponent::class.java)))
+
         Gdx.app.log("MODEL", "Engine loaded")
     }
+
     fun fireShots() {
         val padding = (Configuration.gameHeight - 4*100) / 2
         val buttonHeight = 100
-        var startPosY = InputHandler.playerPosition * buttonHeight + padding
-        var shootPosX = Configuration.gameWidth - 10f - 100f;
-        var shootPosY = InputHandler.playerTrajectoryPosition * buttonHeight + padding
+        val startPosY = InputHandler.playerPosition * buttonHeight + padding
+        val shootPosX = Configuration.gameWidth - 10f - 100f;
+        val shootPosY = InputHandler.playerTrajectoryPosition * buttonHeight + padding
         InputHandler.fireShots = true
         println("Fire shots")
         engine.addEntity(EntityFactory.createTrajectory(engine, 10f, startPosY, true, shootPosX, shootPosY))
     }
+
+    fun changeState() {
+        state = state?.signal()
+    }
+
     fun render(delta: Float) {
         Gdx.gl.glClearColor(0.5f, 0f, 0.2f, 1f)
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
@@ -71,6 +65,7 @@ class Game(private val screenRect: Rectangle, private val camera: OrthographicCa
     fun dispose() {
         engine.dispose()
     }
+
     fun hide() {
         engine.removeAllEntities()
         engine.clearPools()

--- a/core/src/group16/project/game/models/Game.kt
+++ b/core/src/group16/project/game/models/Game.kt
@@ -11,8 +11,9 @@ import group16.project.game.controllers.InputHandler
 import group16.project.game.ecs.Engine
 import group16.project.game.ecs.component.HealthComponent
 import group16.project.game.ecs.utils.EntityFactory
+import group16.project.game.views.GameScreen
 
-class Game(private val screenRect: Rectangle, private val camera: OrthographicCamera) {
+class Game(private val screenRect: Rectangle, private val camera: OrthographicCamera, private val gameScreen: GameScreen) {
     private val batch = SpriteBatch()
     private val engine by lazy {
         Engine(
@@ -54,7 +55,8 @@ class Game(private val screenRect: Rectangle, private val camera: OrthographicCa
     }
 
     fun changeState() {
-        state = state?.signal()
+        state = state.signal()
+        gameScreen.updateUi()
     }
 
     fun render(delta: Float) {

--- a/core/src/group16/project/game/models/GameState.kt
+++ b/core/src/group16/project/game/models/GameState.kt
@@ -2,24 +2,29 @@ package group16.project.game.models
 
 enum class GameState {
     START {
+        override var  text = "Starting..."
         override fun signal() = SETUP
     },
 
     SETUP {
+        override var  text = "Player's Turn"
         override fun signal() = WAITING
     },
 
     WAITING {
+        override var  text = "Waiting For Other Player..."
         override fun signal() = ANIMATION
     },
 
     ANIMATION {
+        override var  text = "Executing Move..."
         override fun signal() = SETUP
     },
 
     GAME_OVER {
+        override var text = "Game Over"
         override fun signal() = GAME_OVER
     };
-
+    open var text = ""
     abstract fun signal(): GameState
 }

--- a/core/src/group16/project/game/models/GameState.kt
+++ b/core/src/group16/project/game/models/GameState.kt
@@ -1,0 +1,25 @@
+package group16.project.game.models
+
+enum class GameState {
+    START {
+        override fun signal() = WAITING
+    },
+
+    WAITING {
+        override fun signal() = SETUP
+    },
+
+    SETUP {
+        override fun signal() = ANIMATION
+    },
+
+    ANIMATION {
+        override fun signal() = WAITING
+    },
+
+    GAME_OVER {
+        override fun signal() = GAME_OVER
+    };
+
+    abstract fun signal(): GameState
+}

--- a/core/src/group16/project/game/models/GameState.kt
+++ b/core/src/group16/project/game/models/GameState.kt
@@ -2,19 +2,19 @@ package group16.project.game.models
 
 enum class GameState {
     START {
-        override fun signal() = WAITING
-    },
-
-    WAITING {
         override fun signal() = SETUP
     },
 
     SETUP {
+        override fun signal() = WAITING
+    },
+
+    WAITING {
         override fun signal() = ANIMATION
     },
 
     ANIMATION {
-        override fun signal() = WAITING
+        override fun signal() = SETUP
     },
 
     GAME_OVER {

--- a/core/src/group16/project/game/views/GameScreen.kt
+++ b/core/src/group16/project/game/views/GameScreen.kt
@@ -24,9 +24,7 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable
-
-
-
+import group16.project.game.models.GameState
 
 
 class GameScreen(val gameController: StarBattle) : View() {
@@ -96,12 +94,22 @@ class GameScreen(val gameController: StarBattle) : View() {
                 game.fireShots()
             }
         })
+
+        val btnChangeState = VisTextButton("Current state: "+game.state.name)
+        btnChangeState.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent, actor: Actor) {
+                game.changeState()
+                btnChangeState.setText("Current state: "+game.state.name)
+            }
+        })
         // Create the layout
         table.columnDefaults(0).pad(10f)
         table.setFillParent(true)
         table.add(btnBack).size(stage.width / 2, 45.0f)
         table.row()
         table.add(btnFire).size(stage.width/2, 45.0f)
+        table.row()
+        table.add(btnChangeState).size(stage.width/2, 45.0f)
         stage.addActor(table)
 
         for (i in 0..1) {
@@ -137,21 +145,26 @@ class GameScreen(val gameController: StarBattle) : View() {
                 if (i == 0)
                     btn.addListener(object : ChangeListener() {
                         override fun changed(event: ChangeEvent, actor: Actor) {
-                            InputHandler.playerPosition = Integer.parseInt(btn.text.toString()).toFloat()
-                            print("PS ")
-                            println(InputHandler.playerPosition)
+                            if (game.state == GameState.SETUP) {
+                                InputHandler.playerPosition = Integer.parseInt(btn.text.toString()).toFloat()
+                                print("PS ")
+                                println(InputHandler.playerPosition)
+                            }
                         }
                     })
                 else
                     btn.addListener(object : ChangeListener() {
                         override fun changed(event: ChangeEvent, actor: Actor) {
-                            InputHandler.playerTrajectoryPosition = Integer.parseInt(btn.text.toString()).toFloat()
-                            print("PTS ")
-                            println(InputHandler.playerTrajectoryPosition)
+                            if (game.state == GameState.SETUP) {
+                                InputHandler.playerTrajectoryPosition = Integer.parseInt(btn.text.toString()).toFloat()
+                                print("PTS ")
+                                println(InputHandler.playerTrajectoryPosition)
+                            }
                         }
                     })
                 vbox.add(btn).size(150f, 100f)
                 vbox.row()
+
                 // BAR
                 val bar = Image(TextureRegionDrawable(TextureRegion(Texture(Gdx.files.internal("bar.png")))))
                 bar.setSize(200f, 40f)
@@ -160,7 +173,7 @@ class GameScreen(val gameController: StarBattle) : View() {
             }
             stage.addActor(vbox)
         }
-        Gdx.app.log("VIEW", "Game loaded")
 
+        Gdx.app.log("VIEW", "Game loaded")
     }
 }


### PR DESCRIPTION
This PR fixes #18 by implementing a simple state manager for handling different states on the game screen view. I see that this is being worked on issue #46 as well, so a future fix will be needed. I believe that this code can still be merged nonetheless as it includes some visual fixes as well. This includes:
- HP display fix for the other player
- Status/State display on the top screen
- Added "End Turn" button
- Added TransformComponent to handle flipped images, rotation, and opacity
- Other minor visual changes

closes #18