### PR TITLE
#52 Add correct scaling of sprites and UI elements on mobile

### DIFF
--- a/core/src/group16/project/game/models/Game.kt
+++ b/core/src/group16/project/game/models/Game.kt
@@ -7,12 +7,14 @@ import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.graphics.OrthographicCamera
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.math.Rectangle
+import com.badlogic.gdx.scenes.scene2d.InputEvent
 import group16.project.game.Configuration
 import group16.project.game.controllers.InputHandler
 import group16.project.game.ecs.Engine
 import group16.project.game.ecs.component.HealthComponent
 import group16.project.game.ecs.utils.EntityFactory
 import group16.project.game.views.GameScreen
+import java.util.*
 
 class Game(private val screenRect: Rectangle, private val camera: OrthographicCamera, private val gameScreen: GameScreen) {
     private val batch = SpriteBatch()
@@ -30,6 +32,7 @@ class Game(private val screenRect: Rectangle, private val camera: OrthographicCa
 
     lateinit var shield1: Entity
     lateinit var shield2: Entity
+    private var timerValue = 0f
 
     fun init() {
         state = GameState.START
@@ -109,18 +112,38 @@ class Game(private val screenRect: Rectangle, private val camera: OrthographicCa
         if (!(this.state == GameState.SETUP && state == GameState.ANIMATION || this.state == GameState.WAITING && state == GameState.SETUP)) {
             this.state = state
             gameScreen.updateUi()
+            timerValue = 0f
+            gameScreen.timer.value = 0f
         }
         if (this.state == GameState.SETUP){
             InputHandler.playerShieldPosition = -1
             InputHandler.enemyShieldPosition = -1
             gameScreen.clicked = false
         }
+
     }
 
     fun render(delta: Float) {
         Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
         engine.update(delta)
+
+        // Setup phase timer
+        if (this.state == GameState.SETUP) {
+            timerValue += Gdx.graphics.deltaTime
+            gameScreen.timer.value = timerValue
+            if (timerValue >= 100f) {
+                // Programmatically click on "End Turn" button
+                val ie = InputEvent()
+                ie.type = InputEvent.Type.touchDown
+                gameScreen.btnEndTurn.fire(ie)
+                ie.type = InputEvent.Type.touchUp
+                gameScreen.btnEndTurn.fire(ie)
+                // Reset timer
+                timerValue = 0f
+                gameScreen.timer.value = 0f
+            }
+        }
     }
 
     fun dispose() {

--- a/core/src/group16/project/game/models/Game.kt
+++ b/core/src/group16/project/game/models/Game.kt
@@ -118,7 +118,7 @@ class Game(private val screenRect: Rectangle, private val camera: OrthographicCa
     }
 
     fun render(delta: Float) {
-        Gdx.gl.glClearColor(0.5f, 0f, 0.2f, 1f)
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
         engine.update(delta)
     }

--- a/core/src/group16/project/game/views/GameScreen.kt
+++ b/core/src/group16/project/game/views/GameScreen.kt
@@ -34,7 +34,8 @@ class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : 
     private val game = Game(screenRect, camera, this)
 
     private val statusText = VisLabel("")
-    private val btnEndTurn = VisTextButton("End Turn")
+    val btnEndTurn = VisTextButton("End Turn")
+    val timer = VisProgressBar(0f, 100f, 0.1f, false)
     private val btnPlaceShield = VisImageButton(TextureRegionDrawable(TextureRegion(Texture(Gdx.files.internal("Shieldbtn.png")))))
     private lateinit var healths: HashMap<String, HealthComponent>
     var bothHit = false
@@ -155,13 +156,17 @@ class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : 
         // Draw bottombox
         val bbox = Image(TextureRegionDrawable(TextureRegion(Texture(Gdx.files.internal("bottombox.png")))))
         bbox.setSize(670f, 90f)
-        bbox.setPosition((stage.width/2) - 670/2f, -15f)
+        bbox.setPosition((stage.width/2) - 670/2f, -5f)
         stage.addActor(bbox)
         val tubox = Image(TextureRegionDrawable(TextureRegion(Texture(Gdx.files.internal("turnbox.png")))))
         tubox.setSize(260f, 70f)
-        tubox.setPosition((stage.width/2) - 130f, 50f)
+        tubox.setPosition((stage.width/2) - 130f, 60f)
         stage.addActor(tubox)
 
+        // Draw setup timer progress bar
+        timer.setSize(stage.width, 50f)
+        timer.setPosition(0f, -20f)
+        stage.addActor(timer)
 
         //Draw lobbyCode label
         var lobbycode = VisLabel(GameInfo.currentGame)
@@ -177,13 +182,13 @@ class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : 
             }
         })
         btnPlaceShield.setSize(50f, 50f)
-        btnPlaceShield.setPosition((stage.width-bbox.width)/2+50, 6f)
+        btnPlaceShield.setPosition((stage.width-bbox.width)/2+50, 16f)
         stage.addActor(btnPlaceShield)
 
         // Draw menu icon
         val cogIcon = Image(TextureRegionDrawable(TextureRegion(Texture(Gdx.files.internal("cog_icon.png")))))
         cogIcon.setSize(50f, 58f)
-        cogIcon.setPosition((stage.width/2) + 670/2f - 100f, 1f)
+        cogIcon.setPosition((stage.width/2) + 670/2f - 100f, 11f)
         val btnMenu = VisTextButton("")
         btnMenu.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent, actor: Actor) {
@@ -220,7 +225,7 @@ class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : 
             }
         })
         btnMenu.setSize(50f, 58f)
-        btnMenu.setPosition((stage.width/2) + 670/2f - 100f, 1f)
+        btnMenu.setPosition((stage.width/2) + 670/2f - 100f, 11f)
         btnMenu.setColor(0f,0f,0f,0f)
         stage.addActor(cogIcon)
         stage.addActor(btnMenu)
@@ -228,7 +233,7 @@ class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : 
         // Draw help icon
         val helpIcon = Image(TextureRegionDrawable(TextureRegion(Texture(Gdx.files.internal("help_icon.png")))))
         helpIcon.setSize(50f, 58f)
-        helpIcon.setPosition((stage.width/2) + 670/2f - 155f, 1f)
+        helpIcon.setPosition((stage.width/2) + 670/2f - 155f, 11f)
         val btnHelp = VisTextButton("")
         btnHelp.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent, actor: Actor) {
@@ -242,7 +247,7 @@ class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : 
             }
         })
         btnHelp.setSize(50f, 58f)
-        btnHelp.setPosition((stage.width/2) + 670/2f - 155f, 1f)
+        btnHelp.setPosition((stage.width/2) + 670/2f - 155f, 11f)
         btnHelp.setColor(0f,0f,0f,0f)
         stage.addActor(helpIcon)
         stage.addActor(btnHelp)
@@ -260,7 +265,7 @@ class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : 
             }
         })
         btnEndTurn.setSize(110f, 30f)
-        btnEndTurn.setPosition((stage.width/2) - 55f, 70f)
+        btnEndTurn.setPosition((stage.width/2) - 55f, 80f)
         stage.addActor(btnEndTurn)
 
 

--- a/core/src/group16/project/game/views/GameScreen.kt
+++ b/core/src/group16/project/game/views/GameScreen.kt
@@ -31,7 +31,6 @@ import group16.project.game.views.components.EndGameComponent
 
 class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : View() {
     private val screenRect = Rectangle(0f, 0f, Configuration.gameWidth, Configuration.gameHeight)
-    private val camera = OrthographicCamera()
     private val game = Game(screenRect, camera, this)
 
     private val statusText = VisLabel("")
@@ -56,8 +55,6 @@ class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : 
 
     override fun resize(width: Int, height: Int) {
         super.resize(width, height)
-        screenRect.width = stage.viewport.worldWidth
-        screenRect.height = stage.viewport.worldHeight
         // Redraw on resize
         stage.clear()
         drawLayout()
@@ -340,5 +337,8 @@ class GameScreen(val gameController: StarBattle, val fbic: FirebaseInterface) : 
         }
         updateUi()
         Gdx.app.log("VIEW", "Game loaded")
+
+        println(stage.viewport.worldWidth)
+        println(Gdx.graphics.width)
     }
 }

--- a/core/src/group16/project/game/views/HighScoreScreen.kt
+++ b/core/src/group16/project/game/views/HighScoreScreen.kt
@@ -13,7 +13,7 @@ class HighScoreScreen(val gameController: StarBattle): View(){
 
     //Players username and score of top 10
     var players = hashMapOf<String, Int>()
-    val txtTitle = VisLabel("High score List")
+    val txtTitle = VisLabel("Leaderboard")
     val btnReturn = VisTextButton("Return to main menu")
 
     override fun init() {

--- a/core/src/group16/project/game/views/MainMenuScreen.kt
+++ b/core/src/group16/project/game/views/MainMenuScreen.kt
@@ -75,7 +75,7 @@ class MainMenuScreen(val gameController: StarBattle, private val fbic: FirebaseI
         })
 
         // add a "HighScore" button
-        val btnHighScore = VisTextButton("High score")
+        val btnHighScore = VisTextButton("Leaderboard")
         btnHighScore.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent, actor: Actor) {
                 gameController.changeScreen(HighScoreScreen::class.java)

--- a/core/src/group16/project/game/views/View.kt
+++ b/core/src/group16/project/game/views/View.kt
@@ -6,9 +6,14 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.ScreenViewport
 import group16.project.game.Configuration
 import com.badlogic.gdx.InputMultiplexer
+import com.badlogic.gdx.graphics.OrthographicCamera
+import com.badlogic.gdx.utils.viewport.ExtendViewport
+import com.badlogic.gdx.utils.viewport.FitViewport
+import com.badlogic.gdx.utils.viewport.StretchViewport
 
 abstract class View : Screen {
-    protected var stage = Stage(ScreenViewport());
+    protected val camera = OrthographicCamera()
+    protected var stage = Stage(FitViewport(Configuration.gameWidth, Configuration.gameHeight, camera));
     override fun show() {
         // Set debug status
         stage.isDebugAll = Configuration.debug
@@ -36,8 +41,8 @@ abstract class View : Screen {
 
     override fun resize(width: Int, height: Int) {
         stage.viewport.update(width, height, true)
-        Configuration.gameWidth = width.toFloat()
-        Configuration.gameHeight = height.toFloat()
+        // Configuration.gameWidth = width.toFloat()
+        // Configuration.gameHeight = height.toFloat()
     }
 
     abstract fun draw(delta: Float)

--- a/core/src/group16/project/game/views/components/EndGameComponent.kt
+++ b/core/src/group16/project/game/views/components/EndGameComponent.kt
@@ -8,13 +8,14 @@ import com.kotcrab.vis.ui.layout.FloatingGroup
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
+import group16.project.game.Configuration
 import group16.project.game.StarBattle
 import group16.project.game.models.Game
 import group16.project.game.views.MainMenuScreen
 
 class EndGameComponent(score: Int, game: Game, gameController: StarBattle): FloatingGroup() {
-    private val WIDTH = Gdx.graphics.width.toFloat()
-    private val HEIGHT = Gdx.graphics.height.toFloat()
+    private val WIDTH = Configuration.gameWidth
+    private val HEIGHT = Configuration.gameHeight
 
     private val header = VisLabel("Game Ended!")
     private var winOrLooseText = VisLabel("")

--- a/core/src/group16/project/game/views/components/PopupComponent.kt
+++ b/core/src/group16/project/game/views/components/PopupComponent.kt
@@ -9,6 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.kotcrab.vis.ui.layout.FloatingGroup
 import com.kotcrab.vis.ui.widget.VisTextButton
+import group16.project.game.Configuration
 
 
 class PopupComponent(child: Actor?, isFullscreen: Boolean = false, hasCloseButton: Boolean = true): FloatingGroup() {
@@ -16,7 +17,7 @@ class PopupComponent(child: Actor?, isFullscreen: Boolean = false, hasCloseButto
     init {
         // Root widget
         this.setPosition(0f, 0f)
-        this.setSize(Gdx.graphics.width.toFloat(), Gdx.graphics.height.toFloat())
+        this.setSize(Configuration.gameWidth, Configuration.gameHeight)
         // Semi-transparent fullscreen
         if (isFullscreen) drawSemiTransparentBackground()
 
@@ -30,7 +31,7 @@ class PopupComponent(child: Actor?, isFullscreen: Boolean = false, hasCloseButto
     fun drawCloseButton() {
         val btnClosePopup = VisTextButton("X")
         btnClosePopup.setSize(60f, 60f)
-        btnClosePopup.setPosition(Gdx.graphics.width.toFloat() - 60f ,Gdx.graphics.height.toFloat() - 60f)
+        btnClosePopup.setPosition(Configuration.gameWidth - 60f ,Configuration.gameHeight - 60f)
         btnClosePopup.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent, actor: Actor) {
                 closePopup()
@@ -56,7 +57,7 @@ class PopupComponent(child: Actor?, isFullscreen: Boolean = false, hasCloseButto
 
         val image = Image(texture)
         image.color.a=.7f
-        image.setSize(Gdx.graphics.width.toFloat(), Gdx.graphics.height.toFloat())
+        image.setSize(Configuration.gameWidth, Configuration.gameHeight)
         this.addActor(image)
     }
 }

--- a/core/src/group16/project/game/views/components/SlideshowComponent.kt
+++ b/core/src/group16/project/game/views/components/SlideshowComponent.kt
@@ -12,10 +12,11 @@ import com.kotcrab.vis.ui.layout.GridGroup
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
+import group16.project.game.Configuration
 
 class SlideshowComponent(private val slides: ArrayList<ImageSlideshowComponent>): FloatingGroup() {
-    private val WIDTH = Gdx.graphics.width.toFloat()
-    private val HEIGHT = Gdx.graphics.height.toFloat()
+    private val WIDTH = Configuration.gameWidth
+    private val HEIGHT = Configuration.gameHeight
 
     private val text = VisLabel("")
     private val display = VisTable()
@@ -88,7 +89,7 @@ class SlideshowComponent(private val slides: ArrayList<ImageSlideshowComponent>)
         text.setText(imgSlideshow.text)
     }
 
-    fun updateDots() {
+    private fun updateDots() {
         dots.clear()
         for (i in 0 until slides.size) {
             if (i == currentSlide) {

--- a/desktop/src/group16/project/game/DesktopFirebaseConnection.kt
+++ b/desktop/src/group16/project/game/DesktopFirebaseConnection.kt
@@ -37,8 +37,8 @@ class DesktopFirebaseConnection : FirebaseInterface {
         //TODO("Not yet implemented")
     }
 
-    override fun setPlayersChoice(position: Int, targetPostion: Int, gameScreen: GameScreen) {
-        //TODO("Not yet implemented")
+    override fun setPlayersChoice(position: Int, targetPostion: Int, shieldPosition: Int, gameScreen: GameScreen) {
+        // TODO("Not yet implemented")
     }
 
     override fun checkIfOpponentReady(screen: GameScreen) {
@@ -67,6 +67,14 @@ class DesktopFirebaseConnection : FirebaseInterface {
 
     override fun resetReady() {
         //TODO("Not yet implemented")
+    }
+
+    override fun deleteLobby() {
+        // TODO("Not yet implemented")
+    }
+
+    override fun removeShield() {
+        // TODO("Not yet implemented")
     }
 
 


### PR DESCRIPTION
This PR adds the necessary code for scaling sprites and UI-elements to a suitable size working on most (if not all) modern mobile phones. A timer for the play state is also added along with a progress bar indicating the timer value.

The game resolution is set to `1280x720`

closes #52 
closes #47 